### PR TITLE
Allow uppercase letters, as well as commas and minus signs in session IDs

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -53,7 +53,7 @@ function forum_session_start() {
 	else if (isset($_GET['PHPSESSID']))
 		$forum_session_id = $_GET['PHPSESSID'];
 
-	if (empty($forum_session_id) || !preg_match('/^[a-z0-9]{16,32}$/', $forum_session_id))
+	if (empty($forum_session_id) || !preg_match('/^[a-z0-9\-,]{16,32}$/i', $forum_session_id))
 	{
 		// Create new session id
 		$forum_session_id = random_key(32, FALSE, TRUE);


### PR DESCRIPTION
I am running punbb on the same domain as another application, and I noticed sessions getting clobbered. I realize punbb always sets the hash argument to true when calling random_key(), making the existing regex work, but in my situation, I am deliberately sharing punbb sessions with this other application. The session IDs PHP's file session handler generates can contain uppercase letters, as well as commas and minus signs (see http://www.php.net/manual/en/function.session-id.php).

As a workaround I could write a fn_forum_session_start_start hook to override forum_session_start() but I'd like you to consider loosening the regex as in this patch.
