### PR TITLE
FORUM_DATABASE_QUERY_MAXIMUM_LENGTH is not defined in install.php

### DIFF
--- a/admin/install.php
+++ b/admin/install.php
@@ -36,6 +36,7 @@ error_reporting(E_ALL);
 // Turn off PHP time limit
 @set_time_limit(0);
 
+require FORUM_ROOT.'include/constants.php';
 // We need some stuff from functions.php
 require FORUM_ROOT.'include/functions.php';
 


### PR DESCRIPTION
When running `admin/install.php`, because the `constants.php` file hasn't been included, the constant `FORUM_DATABASE_QUERY_MAXIMUM_LENGTH` hasn't been defined, and therefore throws the "Insane query. Aborting." error preventing install. This was occurring when using `mysqli` driver.

This simply requires the constants file into `install.php`
