### PR TITLE
Delay creation of FlashMessenger

### DIFF
--- a/include/essentials.php
+++ b/include/essentials.php
@@ -101,9 +101,6 @@ if (!defined('FORUM_CONFIG_LOADED'))
 	require FORUM_CACHE_DIR.'cache_config.php';
 }
 
-require FORUM_ROOT.'include/flash_messenger.php';
-$forum_flash = new FlashMessenger();
-
 // If the request_uri is invalid try fix it
 forum_fix_request_uri();
 
@@ -134,6 +131,9 @@ if (!defined('FORUM_HOOKS_LOADED'))
 	generate_hooks_cache();
 	require FORUM_CACHE_DIR.'cache_hooks.php';
 }
+
+require FORUM_ROOT.'include/flash_messenger.php';
+$forum_flash = new FlashMessenger();
 
 // A good place to add common functions for your extension
 ($hook = get_hook('es_essentials')) ? eval($hook) : null;


### PR DESCRIPTION
The constructor of the FlashMessenger tries to initialize a session with ```forum_session_start``` but the hook in it will never fire since the hooks haven't been loaded at that point. 

None of the code between the old and my proposed new positions tries to use ```$forum_flash```, so it doesn't make a difference from that perspective, but ```fn_forum_session_start_start``` hooks will only fire if ```$forum_flash = new FlashMessenger();``` is AFTER the hook loader.