### PR TITLE
checking empty $_SERVER['HTTPS']

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -1163,7 +1163,7 @@ function get_current_url($max_length = 0)
 	if ($return != null)
 		return $return;
 
-	$protocol = (!isset($_SERVER['HTTPS']) || strtolower($_SERVER['HTTPS']) == 'off') ? 'http://' : 'https://';
+	$protocol = (empty($_SERVER['HTTPS']) || strtolower($_SERVER['HTTPS']) == 'off') ? 'http://' : 'https://';
 	$port = (isset($_SERVER['SERVER_PORT']) && (($_SERVER['SERVER_PORT'] != '80' && $protocol == 'http://') || ($_SERVER['SERVER_PORT'] != '443' && $protocol == 'https://')) && strpos($_SERVER['HTTP_HOST'], ':') === false) ? ':'.$_SERVER['SERVER_PORT'] : '';
 
 	$url = $protocol.$_SERVER['HTTP_HOST'].$port.$_SERVER['REQUEST_URI'];


### PR DESCRIPTION
По мотивам issue #91 и issue #121 - в документации [http://php.net/manual/en/reserved.variables.server.php](url) допускается пустое значение элемента - переделал с учетом такого варианта.
