### PR TITLE
Fix unique key in 'online'-table to accept ipv6 addresses

### DIFF
--- a/admin/install.php
+++ b/admin/install.php
@@ -974,8 +974,8 @@ else
 
 	if (in_array($db_type, array('mysql', 'mysqli', 'mysql_innodb', 'mysqli_innodb')))
 	{
-		$schema['UNIQUE KEYS']['user_id_ident_idx'] = array('user_id', 'ident(25)');
-		$schema['INDEXES']['ident_idx'] = array('ident(25)');
+		$schema['UNIQUE KEYS']['user_id_ident_idx'] = array('user_id', 'ident(40)');
+		$schema['INDEXES']['ident_idx'] = array('ident(40)');
 	}
 
 	$forum_db->create_table('online', $schema);


### PR DESCRIPTION
When accessing a punbb installation with ipv6, under certain
circumstances requests fail with db errors.
This has been caused by truncating the length of ident as
part of the unique id in table 'online' to 25 characters.
This is too short for ipv6 which can have a maximum length
of 40 characters.
This commit changes the length to 40 characters and therefore
fixes this issue.