### PR TITLE
check InnoDB support for new mysql versions

### DIFF
--- a/admin/install.php
+++ b/admin/install.php
@@ -485,7 +485,17 @@ else
 
 			if (!$row || !isset($row['Value']) || strtolower($row['Value']) != 'yes')
 			{
-				error($lang_install['MySQL InnoDB Not Supported']);
+				// check InnoDB support for new mysql versions
+				$result = $forum_db->query("SHOW ENGINES");
+				$found_innodb = false;
+				while ($row = $forum_db->fetch_assoc($result)) {
+					if ($row["Engine"] == "InnoDB") {
+						$found_innodb = true;
+					}
+				}
+				if (!$found_innodb) {
+					error($lang_install['MySQL InnoDB Not Supported']);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- добавляет проверку для новых версий mysql (mysql 5.7) - т.к. SHOW VARIABLES LIKE \'have_innodb\' не срабатывает (нет такой переменной have_innodb) и форум не устанавливался